### PR TITLE
Fixed XPATH for product URLs and cleaned code

### DIFF
--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -6,8 +6,8 @@ import sys
 import click
 import grequests
 from scrapy.crawler import CrawlerProcess
-from utils.spiders import OLXSpider, CGamerSpider
 from utils.constants import MercadoLibreConfig as MLC, HEADERS
+from utils.spiders import OLXSpider, ColombiaGamerSpider as CGamerSpider
 from utils.constants import OLXConfig as OLX, ColombiaGamerConfig as CGamer
 
 

--- a/scraper/test/test_scraper.py
+++ b/scraper/test/test_scraper.py
@@ -4,7 +4,7 @@ This module performs unit tests on the scraper module
 import os
 import json
 import pytest
-from ..utils.spiders import OLXSpider, CGamerSpider
+from ..utils.spiders import OLXSpider, ColombiaGamerSpider as CGamerSpider
 from ..utils.constants import OLXConfig as OLX, ColombiaGamerConfig as CGamer
 from scrapy.crawler import CrawlerProcess
 

--- a/scraper/utils/spiders.py
+++ b/scraper/utils/spiders.py
@@ -19,7 +19,7 @@ class OLXSpider(scrapy.Spider):
                 'indent': 4
             }
         },
-        "FEED_EXPORT_ENCODING": "utf-8",
+        'FEED_EXPORT_ENCODING': 'utf-8',
         'DEPTH_LIMIT': 1,
         'AUTOTHROTTLE_ENABLED': True
     }
@@ -67,7 +67,7 @@ class OLXSpider(scrapy.Spider):
             yield response.follow(url, callback = self.parse_product)
 
 
-class CGamerSpider(scrapy.Spider):
+class ColombiaGamerSpider(scrapy.Spider):
     """
     This spider scraps products from the ColombiaGamer e-commerce site
     """
@@ -81,7 +81,7 @@ class CGamerSpider(scrapy.Spider):
                 'indent': 4
             }
         },
-        "FEED_EXPORT_ENCODING": "utf-8",
+        'FEED_EXPORT_ENCODING': 'utf-8',
         'DEPTH_LIMIT': 1,
         'AUTOTHROTTLE_ENABLED': True
     }
@@ -92,7 +92,7 @@ class CGamerSpider(scrapy.Spider):
         Retrieves product information from the product detail page, and exports
         it to the output json
         """
-        self.log(f'>>>>> ATTEMPTING TO SCRAP {response.url}<<<<<')
+        self.log(f'\n>>>>> ATTEMPTING TO SCRAP {response.url}<<<<<\n')
 
         name_xp = f'//div[@class="{CGamer.TITLE_CLASS.value}"]//h2/text()'
         name = response.xpath(name_xp).get()
@@ -122,7 +122,7 @@ class CGamerSpider(scrapy.Spider):
         description, price, image, and url
         """
         product_xp = (f'//div[contains(@class, "{CGamer.ITEM_CLASS.value}")]//'
-                      'a/@href')
+                      'h2/a/@href')
         product_urls = response.xpath(product_xp).getall()
 
         for url in product_urls:


### PR DESCRIPTION
A small necessary correction for ColombiaGamer scraper. It was retrieving unnecessary additional links