### PR TITLE
Feature/mercadolibre pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ At present only the "scraper" module has been implemented (an initial draft/appr
 
 To run, use 
 
-On Windows: `python .\scraper\scraper.py --site=<index> [--verbose=<0|1>]`
+On Windows: `python .\scraper\scraper.py --site=<index> [--verbose]`
 
-On Linux/Unix: `python3 ./scraper/scraper.py --site=<index> [--verbose=<0|1>]`
+On Linux/Unix: `python3 ./scraper/scraper.py --site=<index> [--verbose]`
 
 The indexes for the sites are:
 
@@ -51,6 +51,6 @@ The indexes for the sites are:
 
 2: ColombiaGamer
 
-...
+*(Other sites are still work in progress...)*
 
-The optional `verbose` argument enables to see detailed information about the response bodies from the performed requests to the APIs
+The optional `verbose` argument enables to see detailed information about the response bodies from the performed requests to the APIs.

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -46,7 +46,7 @@ def _get_all_mercadolibre_urls():
 
 def _scrap_mercadolibre_product_pages(product_responses, verbose):
     """
-    Scraps MercadoLibre 
+    Scraps MercadoLibre's product pages from the passed responses
     """
     records = []
         

--- a/scraper/utils/apis.py
+++ b/scraper/utils/apis.py
@@ -25,7 +25,7 @@ def _parse_endpoint(endpoint, params_dict):
     return parsed_endpoint
 
 
-def send_request(endpoints, params_dict = {}, verbose = False):
+def send_request(endpoints, params_dict = {}, verbose = False, delay = None):
     """
     Attempts to send a request with for the specified list of endpoints.
     If the endpoints have $SITE_ID and $CATEGORY_ID URL parameters, the 

--- a/scraper/utils/constants.py
+++ b/scraper/utils/constants.py
@@ -7,6 +7,11 @@ import urllib.parse
 from enum import Enum
 
 
+HEADERS = {
+    'Content-Type': 'application/json'
+}
+
+
 def _get_test_products(path, html_desc = False):
     """
     Creates a list of test products with the specified test path. The html_desc
@@ -52,11 +57,6 @@ def _get_test_products(path, html_desc = False):
     ]
 
 
-HEADERS = {
-    'Content-Type': 'application/json'
-}
-
-
 class MercadoLibreConfig(Enum):
     """
     This enum provides configuration constants for MercadoLibre scraping
@@ -71,6 +71,8 @@ class MercadoLibreConfig(Enum):
     DESC_URL = f'{DETAIL_URL}/description'
     EXPORT_FILE_PATH = 'export/ml_items.json'
     DELAY_IN_SECS = 1
+    MAX_OFFSET = 1000
+    LIMIT = 5
 
 
 class OLXConfig(Enum):

--- a/scraper/utils/constants.py
+++ b/scraper/utils/constants.py
@@ -72,7 +72,7 @@ class MercadoLibreConfig(Enum):
     EXPORT_FILE_PATH = 'export/ml_items.json'
     DELAY_IN_SECS = 1
     MAX_OFFSET = 1000
-    LIMIT = 5
+    LIMIT = 50
 
 
 class OLXConfig(Enum):


### PR DESCRIPTION
Implemented pagination to MercadoLibre scraping.

The LIMIT constant of the MercadoLibreConfig enum can be used to determine the amount of products per page; hence, the number of pages change according to the maximum value of the offset, denoted by MAX_OFFSET (of 1000 items)

It is exporting files with the name  **ml_items$INDEX.json**, where $INDEX is the number of the scraped page