### PR TITLE
Disabled strict mode on ColombiaGamer scraper

### DIFF
--- a/scraper/utils/spiders.py
+++ b/scraper/utils/spiders.py
@@ -198,7 +198,7 @@ class ColombiaGamerSpider(scrapy.Spider):
 
         barcode_xp = f'//script[@type="{CGamer.ID_CLASS.value}"]/text()'
         barcode_content = response.xpath(barcode_xp).get()
-        barcode = json.loads(barcode_content)['sku']
+        barcode = json.loads(barcode_content, strict = False)['sku']
 
         yield {
             'id_type_product': response.meta['brand'],


### PR DESCRIPTION
Strict mode was causing problems for ColombiaGamer's interpretation of inner JSON in the page's content. It was disabled to avoid problem with line break characters that broke the JSON structure.